### PR TITLE
make CCMenuItemSpriteExtra more robtop-like

### DIFF
--- a/template/default-cpp/cappuccino-sdk/incl/cocos2dx/custom/Sprites/CCMenuItemSpriteExtra/CCMenuItemSpriteExtra.cpp
+++ b/template/default-cpp/cappuccino-sdk/incl/cocos2dx/custom/Sprites/CCMenuItemSpriteExtra/CCMenuItemSpriteExtra.cpp
@@ -1,20 +1,20 @@
 #include "CCMenuItemSpriteExtra.h"
 
-void CCMenuItemSpriteExtra::selected(){
+void CCMenuItemSpriteExtra::selected() {
 	CCMenuItemSprite::selected();
-	auto resize = cocos2d::CCScaleTo::create(0.3, m_sizeMult);
+	auto resize = cocos2d::CCScaleBy::create(0.3, m_fSizeMult);
 	auto bounce = cocos2d::CCEaseBounceOut::create(resize);
 	this->runAction(bounce);
 }
 
-void CCMenuItemSpriteExtra::unselected(){
-	CCMenuItemSprite::selected();
-	auto resize = cocos2d::CCScaleTo::create(0.3, 1.0);
+void CCMenuItemSpriteExtra::unselected() {
+	CCMenuItemSprite::unselected();
+	auto resize = cocos2d::CCScaleBy::create(0.3, 1.0 / m_fSizeMult);
 	auto bounce = cocos2d::CCEaseBounceOut::create(resize);
 	this->runAction(bounce);
 }
 
-void CCMenuItemSpriteExtra::activate{
+void CCMenuItemSpriteExtra::activate() {
 	this->stopAllActions();
 	auto reset = cocos2d::CCScaleTo::create(0.0, m_fOriginalSizeMult);
 	this->runAction(reset);
@@ -23,12 +23,13 @@ void CCMenuItemSpriteExtra::activate{
 
 CCMenuItemSpriteExtra* CCMenuItemSpriteExtra::create(CCNode *normalSprite, CCNode *selectedSprite, CCObject *target, cocos2d::SEL_MenuHandler selector){
 	auto spriteItem = new CCMenuItemSpriteExtra;
-	if (spriteItem && spriteItem->initWithNormalSprite(normalSprite, selectedSprite, nullptr, target, selector)) 
+	if (spriteItem && spriteItem->initWithNormalSprite(normalSprite, selectedSprite, nullptr, target, selector)) {
 		spriteItem->autorelease();
+		spriteItem->m_fOriginalSizeMult = normalSprite->getScale();
+	}
 	else {
 		delete spriteItem;
 		spriteItem = nullptr;
 	}
 	return spriteItem;
-
 }

--- a/template/default-cpp/cappuccino-sdk/incl/cocos2dx/custom/Sprites/CCMenuItemSpriteExtra/CCMenuItemSpriteExtra.cpp
+++ b/template/default-cpp/cappuccino-sdk/incl/cocos2dx/custom/Sprites/CCMenuItemSpriteExtra/CCMenuItemSpriteExtra.cpp
@@ -14,6 +14,12 @@ void CCMenuItemSpriteExtra::unselected(){
 	this->runAction(bounce);
 }
 
+void CCMenuItemSpriteExtra::activate{
+	this->stopAllActions();
+	auto reset = cocos2d::CCScaleTo::create(0.0, m_fOriginalSizeMult);
+	this->runAction(reset);
+	CCMenuItemSprite::activate();
+}
 
 CCMenuItemSpriteExtra* CCMenuItemSpriteExtra::create(CCNode *normalSprite, CCNode *selectedSprite, CCObject *target, cocos2d::SEL_MenuHandler selector){
 	auto spriteItem = new CCMenuItemSpriteExtra;

--- a/template/default-cpp/cappuccino-sdk/incl/cocos2dx/custom/Sprites/CCMenuItemSpriteExtra/CCMenuItemSpriteExtra.h
+++ b/template/default-cpp/cappuccino-sdk/incl/cocos2dx/custom/Sprites/CCMenuItemSpriteExtra/CCMenuItemSpriteExtra.h
@@ -3,10 +3,12 @@
 
 class CCMenuItemSpriteExtra : public cocos2d::CCMenuItemSprite{
 private:
-	float m_sizeMult = 1.25;
+	float m_fSizeMult = 1.25;
+	float m_fOriginalSizeMult;
 public:
 	virtual void selected() override;
 	virtual void unselected() override;
+	virtual void activate() override;
 	static CCMenuItemSpriteExtra* create(CCNode *normalSprite, CCNode *selectedSprite, CCObject *target, cocos2d::SEL_MenuHandler selector);
-	void setSizeMult(float multiplier) { m_sizeMult = 1.25; }
+	void setSizeMult(float multiplier) { m_fSizeMult = multiplier; }
 };


### PR DESCRIPTION
button instantly resizes itself to its default scale factor after being activated, which is how buttons behave visually in geometry dash.