### PR TITLE
override setScale, activate methods, fix setSizeMult, and fix button bugs for CCMenuItemSpriteExtra

### DIFF
--- a/template/default-cpp/cappuccino-sdk/incl/cocos2dx/custom/Sprites/CCMenuItemSpriteExtra/CCMenuItemSpriteExtra.cpp
+++ b/template/default-cpp/cappuccino-sdk/incl/cocos2dx/custom/Sprites/CCMenuItemSpriteExtra/CCMenuItemSpriteExtra.cpp
@@ -17,8 +17,7 @@ void CCMenuItemSpriteExtra::unselected(){
 void CCMenuItemSpriteExtra::activate () {
 	CCMenuItemSprite::activate();
 	this->stopAllActions();
-	auto reset = cocos2d::CCScaleTo::create(0.0, m_origScale);
-	this->runAction(reset);
+	this->setScale(m_origScale);
 }
 
 void CCMenuItemSpriteExtra::setScale(float scale) {

--- a/template/default-cpp/cappuccino-sdk/incl/cocos2dx/custom/Sprites/CCMenuItemSpriteExtra/CCMenuItemSpriteExtra.cpp
+++ b/template/default-cpp/cappuccino-sdk/incl/cocos2dx/custom/Sprites/CCMenuItemSpriteExtra/CCMenuItemSpriteExtra.cpp
@@ -2,18 +2,29 @@
 
 void CCMenuItemSpriteExtra::selected(){
 	CCMenuItemSprite::selected();
-	auto resize = cocos2d::CCScaleTo::create(0.3, m_sizeMult);
+	auto resize = cocos2d::CCScaleTo::create(0.3, m_sizeMult * m_origScale);
 	auto bounce = cocos2d::CCEaseBounceOut::create(resize);
 	this->runAction(bounce);
 }
 
 void CCMenuItemSpriteExtra::unselected(){
-	CCMenuItemSprite::selected();
-	auto resize = cocos2d::CCScaleTo::create(0.3, 1.0);
+	CCMenuItemSprite::unselected();
+	auto resize = cocos2d::CCScaleTo::create(0.3, m_origScale);
 	auto bounce = cocos2d::CCEaseBounceOut::create(resize);
 	this->runAction(bounce);
 }
 
+void CCMenuItemSpriteExtra::activate () {
+	CCMenuItemSprite::activate();
+	this->stopAllActions();
+	auto reset = cocos2d::CCScaleTo::create(0.0, m_origScale);
+	this->runAction(reset);
+}
+
+void CCMenuItemSpriteExtra::setScale(float scale) {
+	CCMenuItemSprite::setScale(scale);	
+	m_origScale = scale;
+}
 
 CCMenuItemSpriteExtra* CCMenuItemSpriteExtra::create(CCNode *normalSprite, CCNode *selectedSprite, CCObject *target, cocos2d::SEL_MenuHandler selector){
 	auto spriteItem = new CCMenuItemSpriteExtra;

--- a/template/default-cpp/cappuccino-sdk/incl/cocos2dx/custom/Sprites/CCMenuItemSpriteExtra/CCMenuItemSpriteExtra.h
+++ b/template/default-cpp/cappuccino-sdk/incl/cocos2dx/custom/Sprites/CCMenuItemSpriteExtra/CCMenuItemSpriteExtra.h
@@ -4,9 +4,12 @@
 class CCMenuItemSpriteExtra : public cocos2d::CCMenuItemSprite{
 private:
 	float m_sizeMult = 1.25;
+	float m_origScale = 1.f;
 public:
 	virtual void selected() override;
 	virtual void unselected() override;
+	virtual void activate() override;
+	virtual void setScale(float scale) override;
 	static CCMenuItemSpriteExtra* create(CCNode *normalSprite, CCNode *selectedSprite, CCObject *target, cocos2d::SEL_MenuHandler selector);
-	void setSizeMult(float multiplier) { m_sizeMult = 1.25; }
+	void setSizeMult(float multiplier) { m_sizeMult = multiplier; }
 };


### PR DESCRIPTION
The previous PRs by both me and @poweredbypie both had some button bugs as well as inconsistencies, this PR cleans them up and should be a drop in fix to fix any CCMenuItemSpriteExtra.